### PR TITLE
Bugfix/108 All posts card is not inline with the skeleton

### DIFF
--- a/frontend/src/components/skeletons/post-card-skeleton.tsx
+++ b/frontend/src/components/skeletons/post-card-skeleton.tsx
@@ -7,18 +7,16 @@ export const PostCardSkeleton = () => {
         <Skeleton className="h-48 w-full rounded-lg bg-slate-200 dark:bg-slate-700" />
         <div className="p-4">
           <Skeleton className="mb-2 h-3 w-full sm:w-2/3 bg-slate-200 dark:bg-slate-700" />
-          <Skeleton className="mb-2 h-6 w-full sm:w-4/5 bg-slate-200 dark:bg-slate-700" />
-          <Skeleton className="h-16 w-full sm:w-11/12 bg-slate-200 dark:bg-slate-700" />
+          <Skeleton className="mb-2 h-6 w-full bg-slate-200 dark:bg-slate-700" />
+          <Skeleton className="h-16 w-full bg-slate-200 dark:bg-slate-700" />
           <div className="mt-2 flex flex-wrap gap-2">
             <Skeleton
-              className={`h-6 w-full sm:w-16 rounded-full ${
-                'sm:mr-8 sm:mt-4'
-              } sm:mb-4 bg-slate-200 dark:bg-slate-700`}
+              className={`h-6 w-full sm:w-16 rounded-full ${'sm:mt-4'
+                } sm:mb-4 bg-slate-200 dark:bg-slate-700`}
             />
             <Skeleton
-              className={`h-6 w-full sm:w-16 rounded-full ${
-                'sm:mr-8 sm:mt-4'
-              } sm:mb-4 bg-slate-200 dark:bg-slate-700`}
+              className={`h-6 w-full sm:w-16 rounded-full ${'sm:mt-4'
+                } sm:mb-4 bg-slate-200 dark:bg-slate-700`}
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary

Width Increase for Title and Description in skeleton

## Description

Increased the width of Title and description skeleton to match with card.

## Images

![image](https://github.com/djbtw/wanderlust/assets/160743795/e01ac08a-5cb1-45d7-bbbb-0550b4efa420)

## Issue(s) Addressed

Closes [#108](https://github.com/krishnaacharyaa/wanderlust/issues/108)

## Prerequisites

- [x] Have you followed all the [CONTRIBUTING GUIDELINES](https://github.com/krishnaacharyaa/wanderlust/blob/main/.github/CONTRIBUTING.md#guidelines-for-contributions)?
